### PR TITLE
ResNet3D VAE fix

### DIFF
--- a/lib/medzoo/ResNet3D_VAE.py
+++ b/lib/medzoo/ResNet3D_VAE.py
@@ -235,7 +235,7 @@ class VAE(nn.Module):
         x = x.view(-1, self.linear_in_dim)
         x = self.linear_1(x)
         mu = x[:, :self.split_dim]
-        logvar = torch.log(x[:, self.split_dim:])
+        logvar = x[:, self.split_dim:]
         y = reparametrize(mu, logvar)
         y = self.linear_vu(y)
         y = y.view(-1, self.encoder_channels, self.reshape_dim[0], self.reshape_dim[1], self.reshape_dim[2])

--- a/lib/medzoo/ResNet3D_VAE.py
+++ b/lib/medzoo/ResNet3D_VAE.py
@@ -254,7 +254,7 @@ class ResNet3dVAE(BaseModel):
     def __init__(self, in_channels=2, classes=4, max_conv_channels=256, dim=(64, 64, 64)):
         super(ResNet3dVAE, self).__init__()
         self.dim = dim
-        vae_in_dim = (int(dim[0] >> 3), int(dim[1] >> 3), int(dim[0] >> 3))
+        vae_in_dim = (int(dim[0] >> 3), int(dim[1] >> 3), int(dim[2] >> 3))
         vae_out_dim = (in_channels, dim[0], dim[1], dim[2])
 
         self.classes = classes


### PR DESCRIPTION
Hi there,

I was just playing around with the package and found a typo in ResNet3D VAE constructor that prevents network for working with inputs where x,y,z dimensions are different (e.g., 56, 64, 48). 

Thanks!
Paul